### PR TITLE
fix(service): properly validate UUID if the format is omitted

### DIFF
--- a/server/src/services/service.ts
+++ b/server/src/services/service.ts
@@ -1,6 +1,6 @@
 import type { Core } from '@strapi/strapi';
 import { errors } from '@strapi/utils';
-import { generateUUID, validateUUID } from '../../../admin/src/utils/helpers';
+import { generateUUID, isValidUUIDValue } from '../../../admin/src/utils/helpers';
 
 const { YupValidationError } = errors;
 
@@ -37,7 +37,7 @@ const service = ({ strapi }: { strapi: Core.Strapi }) => ({
         // - If disableAutoFill is not enabled
         // - If there is an initial value
         if (!disableAutoFill || initialValue) {
-          if (!validateUUID(uuidFormat, event.params.data[attribute])) {
+          if (!isValidUUIDValue(uuidFormat, event.params.data[attribute])) {
             errorMessages.inner.push({
               name: 'ValidationError', // Always set to ValidationError
               path: attribute, // Name of field we want to show input validation on


### PR DESCRIPTION
Encountered an error when adding an entry to a collection type using `strapi-advanced-uuid`.
The issue was that the `validateUUID` function did not account for a default format. 
Updated the code to use an existing function that validates the UUID regardless of whether a format is provided.

`[2024-11-14 14:28:03.742] error: You have some issues
ValidationError: You have some issues
    at Object.handleCRUDOperation (D:\*****\node_modules\strapi-advanced-uuid\dist\server\index.js:25091:13)
    at Object.beforeUpdate (D:\*****\node_modules\strapi-advanced-uuid\dist\server\index.js:52:54)
    at Object.run (D:\*****\node_modules\@strapi\database\dist\index.js:6844:37)
    at async Object.update (D:\*****\node_modules\@strapi\database\dist\index.js:5435:22)
    at async update (D:\*****\node_modules\@strapi\core\dist\services\document-service\repository.js:173:22)
    at async D:\*****\node_modules\@strapi\database\dist\index.js:7044:21
    at async Array.databaseErrorsMiddleware (D:\*****\node_modules\@strapi\core\dist\services\document-service\middlewares\errors.js:13:12)
    at async Object.update (D:\*****\node_modules\@strapi\content-manager\dist\server\index.js:2004:28)
    at async returnBodyMiddleware (D:\*****\node_modules\@strapi\core\dist\services\server\compose-endpoint.js:45:18)
    at async routing (D:\*****\node_modules\@strapi\content-manager\dist\server\index.js:942:3)`